### PR TITLE
Making comment identification depend on current user

### DIFF
--- a/client/src/pages/proposalDetails/DiscussionPost.js
+++ b/client/src/pages/proposalDetails/DiscussionPost.js
@@ -1,19 +1,24 @@
 import './DiscussionPost.css';
 
-function ConditionalUserNameRender(isAdmin, userName) {
+function ConditionalUserNameRender(isAdmin, userName, isHighlighted) {
   if (isAdmin) {
     return (
       <div>
         {userName}
       </div>);
+  } else if (isHighlighted) {
+      return (
+        <div>
+          Anon User (You)
+        </div>)
   } else {
     return <div>Anon User</div>;
   }
 }
 
-function ConditionalUserDisplay(userID) {
-  console.log(userID);
-  if (userID === 2) {
+function ConditionalUserDisplay(isHighlighted) {
+  //console.log(userID);
+  if (isHighlighted) {
     return "text-highlighted";
   }
   return "text";
@@ -23,9 +28,9 @@ function DiscussionPost(props) {
   return (
     <div className="post">
       <div className="user">
-        {ConditionalUserNameRender(props.isAdmin, props.userName)}
+        {ConditionalUserNameRender(props.isAdmin, props.userName, props.isHighlighted)}
       </div>
-      <div className={ConditionalUserDisplay(props.id)}>
+      <div className={ConditionalUserDisplay(props.isHighlighted)}>
         <div className="content">
           {props.text}
         </div>

--- a/client/src/pages/proposalDetails/ProposalDetails.js
+++ b/client/src/pages/proposalDetails/ProposalDetails.js
@@ -281,7 +281,7 @@ function ProposalDetails(props) {
           <a className="proposalLink" href = {proposalLink}>{proposalTitle}.pdf</a>
           <div className="proposalAmount"> Proposal Amount: {`$${proposalAmount}`}</div>
           {ProposalConditionalRender(PRIVILEGES, USER_ID)}
-        </div>
+        </div>;
         
       </div>
 
@@ -293,7 +293,7 @@ function ProposalDetails(props) {
         <div className='discussionCommentsView'>
         {comments.map((comment) => (
           // tgif.sql for comments on IS_ADMIN in comments db
-          <DiscussionPost isAdmin={PRIVILEGES==='Admin'} userName={ANON} id={comment.user_id} text={comment.comment_text} time={timestampToReadableDate(comment.time_posted)}/>
+          <DiscussionPost isAdmin={PRIVILEGES==='Admin'} userName={ANON} isHighlighted={comment.user_id === USER_ID} id={comment.user_id} text={comment.comment_text} time={timestampToReadableDate(comment.time_posted)}/>
         ))}
         </div>
         <div className='discussionPostCommentFrame'>

--- a/db/tgif.sql
+++ b/db/tgif.sql
@@ -87,6 +87,7 @@ VALUES
     ('Voting Member', 'Elias Garcia', 'elias_garcia@berkeley.edu', 'Environmental Justice - At Large Representative'),
     ('Voting Member', 'Sarah Bui', 'sarah.bui123@berkeley.edu', 'Undergraduate At-Large Representative'),
     ('Voting Member', 'Anh Pham', 'anhvpham@berkeley.edu', 'rubiks cube master 9000'),
+    ('Voting Member', 'Bailey Segall', 'bailey.segall@berkeley.edu', 'MAN'),
 
     ('Non-Voting Member', 'Sharon Daraphonhdeth', 'sharon@berkeley.edu', 'SERC Director'),
     ('Non-Voting Member', 'Harrisen Min', 'harrisen.min@berkeley.edu', 'Committee on Student Fees Representative'),
@@ -126,4 +127,4 @@ VALUES
 INSERT INTO comments(time_posted, comment_text, user_id, proposal_id)
 VALUES
     ('2021-04-05T10:27:41.886Z', 'I really want to be highlighted', 2, 1),
-    ('2021-04-06T13:45:41.886Z', 'I don''t quite see the value in being highlighted', 3, 1),
+    ('2021-04-06T13:45:41.886Z', 'I don''t quite see the value in being highlighted', 3, 1);


### PR DESCRIPTION
## Motivation
Had hardcoded the current user (2) when did issue 36 but used Kalea and Kennedy's current user.

Issue # (issue if applicable)
36

## Summary of Changes

Feel free to use sentences or a bulleted list.

- created variable for isHighlighted determining whether it should be highlighted or not.
- if is Highlighted comment should be green
- if is Highlighted shows Anon (You)

## Testing

Explain how you tested these changes (unit tests, manual UI testing, etc.) or N/A if testing is not necessary (and explain why).

Played with it on screen

## Screenshot/Gif of results
<img width="1269" alt="Screen Shot 2021-05-04 at 6 34 13 PM" src="https://user-images.githubusercontent.com/77827221/117088497-738e1600-ad07-11eb-8c4b-2e4d3b0aca60.png">

